### PR TITLE
Add missing netaddr requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
+        'netaddr',
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
This is a no-brainer but nevertheless, below is the traceback I got when running a test against a fresh install:

ImportError: Failed to import test module: authentication.tests.test_authentication
Traceback (most recent call last):
  File "ENV/lib/python2.6/site-packages/django/utils/unittest/loader.py", line 260, in _find_tests
    module = self._get_module_from_name(name)
  File "ENV/lib/python2.6/site-packages/django/utils/unittest/loader.py", line 238, in _get_module_from_name
    __import__(name)
  File "SRC/authentication/tests/test_authentication.py", line 7, in <module>
    from restrictedsessions.middleware import RestrictedSessionsMiddleware
  File "ENV/lib/python2.6/site-packages/restrictedsessions/middleware.py", line 2, in <module>
    from netaddr import IPNetwork, IPAddress, AddrConversionError
ImportError: No module named netaddr
