### PR TITLE
Upgraded Python and Django versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@
 language: python
 
 python:
-  - "3.3"
+  - "3.4"
   - "2.7"
-  - "2.6"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-django>=1.5.1
+django>=1.8.13
 coverage
 coveralls
 mock>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django>=1.5.1
+django>=1.8.13
 wheel==0.22.0
 netaddr>=0.7.10

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
 )


### PR DESCRIPTION
We now only build 2.7 and 3.4 on Django 1.8 or 1.9, as they are the
current supported versions.