### PR TITLE
Support for new middleware plus updated tox/ci/pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 language: python
 
 python:
+  - "3.6"
+  - "3.5"
   - "3.4"
   - "2.7"
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,4 @@ Contributors
 
 * Matt Davis <matteius@gmail.com>
 * Rainer Koirikivi <rainer@koirikivi.fi>
-
+* Daniel Roy Greenfeld <pydanny@gmail.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+0.2.0 (2017-03-28)
+++++++++++++++++++
+
+* For Django 1.10+ support, change from `object` to `django.utils.deprecation.MiddlewareMixin`
+* Added PyPI trove classifiers for Django versions and more Python versions
+* Updated `travis.yml` for more Python versions
+
 0.1.4 (2016-07-02)
 ++++++++++++++++++
 

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -2,12 +2,17 @@
 from netaddr import IPNetwork, IPAddress, AddrConversionError, AddrFormatError
 import logging
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.encoding import force_text
 
-from django.conf import settings
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 
 SESSION_IP_KEY = '_restrictedsessions_ip'
 SESSION_UA_KEY = '_restrictedsessions_ua'
@@ -15,7 +20,7 @@ SESSION_UA_KEY = '_restrictedsessions_ua'
 logger = logging.getLogger('restrictedsessions')
 
 
-class RestrictedSessionsMiddleware(object):
+class RestrictedSessionsMiddleware(MiddlewareMixin):
     def process_request(self, request):
         # Short circuit when request doesn't have session
         if not hasattr(request, 'session'):

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -51,5 +54,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    patterns = lambda x**: list(x)
 from django.http import HttpResponse
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py35, py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
This pull request is to resolve #11:

* Adds support for the post-Django 1.10 middleware
* Adds backward compatibility for removal of the `pattern` function
* Updates tox to include more versions of Python
* Updates travis to include more versions of Python
* Adds trove classifiers for supported versions of Django and more Python versions

# WARNING: Tests are failing at this time!

As I'm not that familiar with nose, I cannot resolve this error when tests are run against Python 3.6:

``` traceback
$ python runtests.py 
nosetests tests -s --verbosity=1
Creating test database for alias 'default'...
.................E..
======================================================================
ERROR: test_without_remote_addr_still_check_user_agent_when_redirect (tests.test_middleware.TestRestrictedsessionsMiddleware)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/danielgreenfeld/.virtualenvs/siege/lib/python3.6/site-packages/nose/case.py", line 134, in run
    self.runTest(result)
  File "/Users/danielgreenfeld/.virtualenvs/siege/lib/python3.6/site-packages/nose/case.py", line 152, in runTest
    test(result)
  File "/usr/local/Cellar/python36/3.6.0b1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 648, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/Cellar/python36/3.6.0b1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 608, in run
    self._feedErrorsToResult(result, outcome.errors)
  File "/usr/local/Cellar/python36/3.6.0b1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 538, in _feedErrorsToResult
    result.addError(test, exc_info)
  File "/Users/danielgreenfeld/.virtualenvs/siege/lib/python3.6/site-packages/nose/proxy.py", line 132, in addError
    self.result.addError(self.test, self._prepareErr(err))
  File "/Users/danielgreenfeld/.virtualenvs/siege/lib/python3.6/site-packages/nose/result.py", line 61, in addError
    exc_info = self._exc_info_to_string(err, test)
  File "/Users/danielgreenfeld/.virtualenvs/siege/lib/python3.6/site-packages/nose/result.py", line 187, in _exc_info_to_string
    return _TextTestResult._exc_info_to_string(self, err, test)
  File "/usr/local/Cellar/python36/3.6.0b1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/result.py", line 186, in _exc_info_to_string
    exctype, value, tb, limit=length, capture_locals=self.tb_locals)
  File "/usr/local/Cellar/python36/3.6.0b1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/traceback.py", line 504, in __init__
    self.filename = exc_value.filename
AttributeError: 'SyntaxError' object has no attribute 'filename'
-------------------- >> begin captured logging << --------------------
restrictedsessions: WARNING: Destroyed session due to invalid change of remote host or user agent
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
```